### PR TITLE
New definition for vehicle turnaround times

### DIFF
--- a/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.1.json
+++ b/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.1.json
@@ -1,0 +1,486 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Vehicle turnaround times",
+    "description": "Turnaround times of vehicles within a facility.",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/Transport/Vehicle/TurnaroundTimes_v0.1": {
+      "post": {
+        "tags": ["Logistics"],
+        "summary": "Vehicle turnaround times",
+        "description": "Turnaround times of vehicles within a facility.",
+        "operationId": "request_Transport_Vehicle_TurnaroundTimes_v0_1",
+        "parameters": [
+          {
+            "name": "x-consent-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Optional consent token",
+              "default": "",
+              "title": "X-Consent-Token"
+            },
+            "description": "Optional consent token"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The login token. Value should be \"Bearer [token]\"",
+              "default": "",
+              "title": "Authorization"
+            },
+            "description": "The login token. Value should be \"Bearer [token]\""
+          },
+          {
+            "name": "x-authorization-provider",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The bare domain of the system that provided the token.",
+              "title": "X-Authorization-Provider"
+            },
+            "description": "The bare domain of the system that provided the token."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TurnaroundTimeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TurnaroundTimeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "444": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceNotFound"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadGateway"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          },
+          "504": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                }
+              }
+            },
+            "description": "Gateway Timeout"
+          },
+          "550": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DoesNotConformToDefinition"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BadGateway": {
+        "properties": {},
+        "type": "object",
+        "title": "BadGateway",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "DataSourceError": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "DataSourceError"
+      },
+      "DataSourceNotFound": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": "Data source not found"
+          }
+        },
+        "type": "object",
+        "title": "DataSourceNotFound",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "DoesNotConformToDefinition": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": "Response from data source does not conform to definition"
+          },
+          "data_source_status_code": {
+            "type": "integer",
+            "title": "Data source status code",
+            "description": "HTTP status code returned from the data source"
+          }
+        },
+        "type": "object",
+        "required": ["data_source_status_code"],
+        "title": "DoesNotConformToDefinition",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "Forbidden": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Forbidden"
+      },
+      "GatewayTimeout": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "GatewayTimeout",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "NotFound": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "NotFound"
+      },
+      "RateLimitExceeded": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": "Rate limit exceeded"
+          }
+        },
+        "type": "object",
+        "title": "RateLimitExceeded",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "ServiceUnavailable": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "ServiceUnavailable",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "TurnaroundTime": {
+        "properties": {
+          "vehicleId": {
+            "type": "string",
+            "maxLength": 40,
+            "title": "Vehicle identifier",
+            "description": "Licence plate number or similar identification number of the vehicle.",
+            "examples": ["ABC-123"]
+          },
+          "vehicleType": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 40
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vehicle type",
+            "description": "The type of the vehicle.",
+            "examples": ["truck"]
+          },
+          "entryTime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Entry time",
+            "description": "The time when the vehicle entered the facility.",
+            "examples": ["2023-04-12T22:20:50Z"]
+          },
+          "leaveTime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Leave time",
+            "description": "The time when the vehicle left the facility.",
+            "examples": ["2023-04-12T23:20:50Z"]
+          },
+          "turnaroundTime": {
+            "type": "integer",
+            "title": "Turnaround time (s)",
+            "description": "Turnaround time of the vehicle in seconds.",
+            "examples": [3600]
+          }
+        },
+        "type": "object",
+        "required": ["vehicleId", "entryTime", "turnaroundTime"],
+        "title": "TurnaroundTime"
+      },
+      "TurnaroundTimeRequest": {
+        "properties": {
+          "locationId": {
+            "type": "string",
+            "maxLength": 40,
+            "title": "Location identifier",
+            "description": "Location identification number based on UN/LOCODE, or other similar identification number of the transport location or facility.",
+            "examples": ["FI OUL"]
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start time",
+            "description": "The start time of the performance period, in RFC 3339 format.",
+            "examples": ["2023-04-12T23:20:50Z"]
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End time",
+            "description": "The end time of the performance period in, RFC 3339 format.",
+            "examples": ["2023-05-12T23:20:50Z"]
+          }
+        },
+        "type": "object",
+        "required": ["locationId", "startTime", "endTime"],
+        "title": "TurnaroundTimeRequest"
+      },
+      "TurnaroundTimeResponse": {
+        "properties": {
+          "turnaroundTimes": {
+            "items": {
+              "$ref": "#/components/schemas/TurnaroundTime"
+            },
+            "type": "array",
+            "title": "Turnaround times",
+            "description": "The list of turnaround times of vehicles within the facility."
+          }
+        },
+        "type": "object",
+        "required": ["turnaroundTimes"],
+        "title": "TurnaroundTimeResponse"
+      },
+      "Unauthorized": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Unauthorized"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.1.json
+++ b/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.1.json
@@ -405,14 +405,14 @@
             "type": "string",
             "format": "date-time",
             "title": "Start time",
-            "description": "The start time of the performance period, in RFC 3339 format.",
+            "description": "The start time of the time range to get turnaround times for, in RFC 3339 format.",
             "examples": ["2023-04-12T23:20:50Z"]
           },
           "endTime": {
             "type": "string",
             "format": "date-time",
             "title": "End time",
-            "description": "The end time of the performance period in, RFC 3339 format.",
+            "description": "The end time of the time range to get turnaround times for, in RFC 3339 format.",
             "examples": ["2023-05-12T23:20:50Z"]
           }
         },

--- a/DataProducts/Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1.json
+++ b/DataProducts/Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Vehicle turnaround time",
     "description": "Turnaround time of a vehicle within a facility",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1": {
@@ -11,6 +11,7 @@
         "summary": "Vehicle turnaround time",
         "description": "Turnaround time of a vehicle within a facility",
         "operationId": "request_Transport_Vehicles_TurnaroundTime_VehicleTurnaroundTime_v0_1",
+        "deprecated": true,
         "parameters": [
           {
             "name": "x-consent-token",

--- a/src/Transport/Vehicle/TurnaroundTimes_v0.1.py
+++ b/src/Transport/Vehicle/TurnaroundTimes_v0.1.py
@@ -1,0 +1,90 @@
+import datetime
+from typing import List, Optional
+
+from definition_tooling.converter import CamelCaseModel, DataProductDefinition
+from pydantic import Field
+
+
+class TurnaroundTime(CamelCaseModel):
+    vehicle_id: str = Field(
+        ...,
+        title="Vehicle identifier",
+        description="Licence plate number or similar identification number of the "
+        "vehicle.",
+        max_length=40,
+        examples=["ABC-123"],
+    )
+    vehicle_type: Optional[str] = Field(
+        None,
+        title="Vehicle type",
+        description="The type of the vehicle.",
+        max_length=40,
+        examples=["truck"],
+    )
+    entry_time: datetime.datetime = Field(
+        ...,
+        title="Entry time",
+        description="The time when the vehicle entered the facility.",
+        examples=[
+            datetime.datetime(2023, 4, 12, 22, 20, 50, tzinfo=datetime.timezone.utc)
+        ],
+    )
+    leave_time: Optional[datetime.datetime] = Field(
+        None,
+        title="Leave time",
+        description="The time when the vehicle left the facility.",
+        examples=[
+            datetime.datetime(2023, 4, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
+        ],
+    )
+    turnaround_time: int = Field(
+        ...,
+        title="Turnaround time (s)",
+        description="Turnaround time of the vehicle in seconds.",
+        examples=[3600],
+    )
+
+
+class TurnaroundTimeRequest(CamelCaseModel):
+    location_id: str = Field(
+        ...,
+        title="Location identifier",
+        max_length=40,
+        description="Location identification number based on UN/LOCODE, or other "
+        "similar identification number of the transport location or facility.",
+        examples=["FI OUL"],
+    )
+    start_time: datetime.datetime = Field(
+        ...,
+        title="Start time",
+        description="The start time of the performance period, in RFC 3339 format.",
+        examples=[
+            datetime.datetime(2023, 4, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
+        ],
+    )
+    end_time: datetime.datetime = Field(
+        ...,
+        title="End time",
+        description="The end time of the performance period in, RFC 3339 format.",
+        examples=[
+            datetime.datetime(2023, 5, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
+        ],
+    )
+
+
+class TurnaroundTimeResponse(CamelCaseModel):
+    turnaround_times: List[TurnaroundTime] = Field(
+        ...,
+        title="Turnaround times",
+        description="The list of turnaround times of vehicles within the facility.",
+    )
+
+
+DEFINITION = DataProductDefinition(
+    version="0.1.0",
+    title="Vehicle turnaround times",
+    description="Turnaround times of vehicles within a facility.",
+    tags=["Logistics"],
+    request=TurnaroundTimeRequest,
+    response=TurnaroundTimeResponse,
+)

--- a/src/Transport/Vehicle/TurnaroundTimes_v0.1.py
+++ b/src/Transport/Vehicle/TurnaroundTimes_v0.1.py
@@ -57,7 +57,8 @@ class TurnaroundTimeRequest(CamelCaseModel):
     start_time: datetime.datetime = Field(
         ...,
         title="Start time",
-        description="The start time of the performance period, in RFC 3339 format.",
+        description="The start time of the time range to get turnaround times for, in "
+        "RFC 3339 format.",
         examples=[
             datetime.datetime(2023, 4, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
         ],
@@ -65,7 +66,8 @@ class TurnaroundTimeRequest(CamelCaseModel):
     end_time: datetime.datetime = Field(
         ...,
         title="End time",
-        description="The end time of the performance period in, RFC 3339 format.",
+        description="The end time of the time range to get turnaround times for, in "
+        "RFC 3339 format.",
         examples=[
             datetime.datetime(2023, 5, 12, 23, 20, 50, tzinfo=datetime.timezone.utc)
         ],

--- a/src/Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1.py
+++ b/src/Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1.py
@@ -39,9 +39,10 @@ class VehicleTurnaroundTimeResponse(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Vehicle turnaround time",
     description="Turnaround time of a vehicle within a facility",
     request=VehicleTurnaroundTimeRequest,
     response=VehicleTurnaroundTimeResponse,
+    deprecated=True,
 )


### PR DESCRIPTION
This PR adds a new `Transport/Vehicle/TurnaroundTimes_v0.1` definition that should eventually replace the old, now deprecated, 
`Transport/Vehicles/TurnaroundTime/VehicleTurnaroundTime_v0.1` definition. The path and name is improved and the actual definition improved to better match real world use cases.