### PR TITLE
Update python version in actions

### DIFF
--- a/.github/workflows/convert.yaml
+++ b/.github/workflows/convert.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install python dependencies
         run: pip install pre-commit ioxio-data-product-definition-tooling

--- a/.github/workflows/validation-template.yaml
+++ b/.github/workflows/validation-template.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python 🐍
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Install definition tooling
         run: pip install ioxio-data-product-definition-tooling


### PR DESCRIPTION
Apparently there's a difference in how datetime works between 3.9 and 3.11:
```
Python 3.9.18 (main, Jan 16 2024, 14:53:07)
>>> from datetime import datetime
>>> datetime.fromisoformat("2023-04-12T23:45:00Z")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: Invalid isoformat string: '2023-04-12T23:45:00Z'
```
vs
```
Python 3.11.7 (main, Feb  7 2024, 13:09:39) [Clang 14.0.0 (clang-1400.0.29.202)] on darwin
>>> from datetime import datetime
>>> datetime.fromisoformat("2023-04-12T23:45:00Z")
datetime.datetime(2023, 4, 12, 23, 45, tzinfo=datetime.timezone.utc)
```

This caused one of the pipelines to fail in GitHub actions, whereas it worked just fine locally. Preferring to update to newer Python version here rather than changing the definition.

I'll submit an update to the template repo as well.