### PR TITLE
Update Transport/Vehicle/EstimatedArrivalTimes

### DIFF
--- a/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.1.json
+++ b/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Estimated arrival times",
     "description": "Estimated arrival times of vehicles within a transport location.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/Transport/Vehicle/EstimatedArrivalTimes_v0.1": {
@@ -12,6 +12,7 @@
         "summary": "Estimated arrival times",
         "description": "Estimated arrival times of vehicles within a transport location.",
         "operationId": "request_Transport_Vehicle_EstimatedArrivalTimes_v0_1",
+        "deprecated": true,
         "parameters": [
           {
             "name": "x-consent-token",

--- a/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
+++ b/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
@@ -1,0 +1,498 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Estimated arrival times",
+    "description": "Estimated arrival times of vehicles within a transport location.",
+    "version": "0.2.0"
+  },
+  "paths": {
+    "/Transport/Vehicle/EstimatedArrivalTimes_v0.2": {
+      "post": {
+        "tags": ["ETA", "Logistics"],
+        "summary": "Estimated arrival times",
+        "description": "Estimated arrival times of vehicles within a transport location.",
+        "operationId": "request_Transport_Vehicle_EstimatedArrivalTimes_v0_2",
+        "parameters": [
+          {
+            "name": "x-consent-token",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "Optional consent token",
+              "default": "",
+              "title": "X-Consent-Token"
+            },
+            "description": "Optional consent token"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "description": "The login token. Value should be \"Bearer [token]\"",
+              "default": "",
+              "title": "Authorization"
+            },
+            "description": "The login token. Value should be \"Bearer [token]\""
+          },
+          {
+            "name": "x-authorization-provider",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The bare domain of the system that provided the token.",
+              "title": "X-Authorization-Provider"
+            },
+            "description": "The bare domain of the system that provided the token."
+          },
+          {
+            "name": "x-api-key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-API-Key",
+              "description": "API key or token"
+            },
+            "description": "API key or token"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Request"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Response"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Unauthorized"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Forbidden"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFound"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitExceeded"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          },
+          "444": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceNotFound"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataSourceError"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BadGateway"
+                }
+              }
+            },
+            "description": "Bad Gateway"
+          },
+          "503": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailable"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          },
+          "504": {
+            "content": {
+              "text/plain": {},
+              "text/html": {},
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GatewayTimeout"
+                }
+              }
+            },
+            "description": "Gateway Timeout"
+          },
+          "550": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DoesNotConformToDefinition"
+                }
+              }
+            },
+            "description": "Additional Response"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BadGateway": {
+        "properties": {},
+        "type": "object",
+        "title": "BadGateway",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "DataSourceError": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "DataSourceError"
+      },
+      "DataSourceNotFound": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": "Data source not found"
+          }
+        },
+        "type": "object",
+        "title": "DataSourceNotFound",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "DoesNotConformToDefinition": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Message",
+            "default": "Response from data source does not conform to definition"
+          },
+          "data_source_status_code": {
+            "type": "integer",
+            "title": "Data source status code",
+            "description": "HTTP status code returned from the data source"
+          }
+        },
+        "type": "object",
+        "required": ["data_source_status_code"],
+        "title": "DoesNotConformToDefinition",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "EstimatedArrival": {
+        "properties": {
+          "vehicleId": {
+            "type": "string",
+            "maxLength": 128,
+            "title": "Vehicle identifier",
+            "description": "Licence plate number or similar identification number of the vehicle or vessel.",
+            "examples": ["ABC-123"]
+          },
+          "vehicleName": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vehicle name",
+            "description": "Name of the vehicle or vessel.",
+            "examples": ["Havelland"]
+          },
+          "vehicleType": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 128
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vehicle type",
+            "description": "The type of the arriving vehicle.",
+            "examples": ["container ship", "truck"]
+          },
+          "estimatedArrival": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Estimated arrival",
+            "description": "Expected time of arrival for the vehicle to the facility, in RFC 3339 format.",
+            "examples": ["2023-04-12T23:45:00Z"]
+          }
+        },
+        "type": "object",
+        "required": ["vehicleId", "estimatedArrival"],
+        "title": "EstimatedArrival"
+      },
+      "Forbidden": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Forbidden"
+      },
+      "GatewayTimeout": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "GatewayTimeout",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "NotFound": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "NotFound"
+      },
+      "RateLimitExceeded": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": "Rate limit exceeded"
+          }
+        },
+        "type": "object",
+        "title": "RateLimitExceeded",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "Request": {
+        "properties": {
+          "locationId": {
+            "type": "string",
+            "maxLength": 40,
+            "title": "Location identifier",
+            "description": "Location identification number based on UN/LOCODE, IATA or other similar identification number of the transport location.",
+            "examples": ["FIOUL"]
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start time",
+            "description": "The start time of the evaluation period, in RFC 3339 format.",
+            "examples": ["2023-04-12T23:20:50Z"]
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End time",
+            "description": "The end time of the evaluation period, in RFC 3339 format.",
+            "examples": ["2023-05-12T23:20:50Z"]
+          }
+        },
+        "type": "object",
+        "required": ["locationId", "startTime", "endTime"],
+        "title": "Request"
+      },
+      "Response": {
+        "properties": {
+          "estimatedArrivals": {
+            "items": {
+              "$ref": "#/components/schemas/EstimatedArrival"
+            },
+            "type": "array",
+            "title": "Estimated arrivals",
+            "description": "Estimated arrival times."
+          }
+        },
+        "type": "object",
+        "required": ["estimatedArrivals"],
+        "title": "Response"
+      },
+      "ServiceUnavailable": {
+        "properties": {
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "ServiceUnavailable",
+        "description": "This response is reserved by Product Gateway."
+      },
+      "Unauthorized": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Error type",
+            "description": "Error identifier"
+          },
+          "message": {
+            "type": "string",
+            "title": "Error message",
+            "description": "Error description"
+          }
+        },
+        "type": "object",
+        "required": ["type", "message"],
+        "title": "Unauthorized"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
+++ b/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
@@ -312,10 +312,19 @@
             "title": "Estimated arrival",
             "description": "Expected time of arrival for the vehicle to the facility, in RFC 3339 format.",
             "examples": ["2023-04-12T23:45:00Z"]
+          },
+          "waybills": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Waybills",
+            "description": "The list of waybills being carried within the vehicle.",
+            "examples": [["DGT1234567", "FTP7654321"]]
           }
         },
         "type": "object",
-        "required": ["vehicleId", "estimatedArrival"],
+        "required": ["vehicleId", "estimatedArrival", "waybills"],
         "title": "EstimatedArrival"
       },
       "Forbidden": {

--- a/src/Transport/Vehicle/EstimatedArrivalTimes_v0.1.py
+++ b/src/Transport/Vehicle/EstimatedArrivalTimes_v0.1.py
@@ -69,7 +69,8 @@ class Response(CamelCaseModel):
 
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
+    deprecated=True,
     title="Estimated arrival times",
     description="Estimated arrival times of vehicles within a transport location.",
     tags=["Logistics", "ETA"],

--- a/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
+++ b/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
@@ -35,6 +35,12 @@ class EstimatedArrival(CamelCaseModel):
         "3339 format.",
         examples=[datetime.fromisoformat("2023-04-12T23:45:00Z")],
     )
+    waybills: list[str] = Field(
+        ...,
+        title="Waybills",
+        description="The list of waybills being carried within the vehicle.",
+        examples=[["DGT1234567", "FTP7654321"]],
+    )
 
 
 class Request(CamelCaseModel):

--- a/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
+++ b/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
@@ -1,0 +1,78 @@
+from datetime import datetime
+from typing import Optional
+
+from definition_tooling.converter import CamelCaseModel, DataProductDefinition
+from pydantic import Field
+
+
+class EstimatedArrival(CamelCaseModel):
+    vehicle_id: str = Field(
+        ...,
+        title="Vehicle identifier",
+        description="Licence plate number or similar identification number of the "
+        "vehicle or vessel.",
+        max_length=128,
+        examples=["ABC-123"],
+    )
+    vehicle_name: Optional[str] = Field(
+        None,
+        title="Vehicle name",
+        description="Name of the vehicle or vessel.",
+        max_length=128,
+        examples=["Havelland"],
+    )
+    vehicle_type: Optional[str] = Field(
+        None,
+        title="Vehicle type",
+        description="The type of the arriving vehicle.",
+        max_length=128,
+        examples=["container ship", "truck"],
+    )
+    estimated_arrival: datetime = Field(
+        ...,
+        title="Estimated arrival",
+        description="Expected time of arrival for the vehicle to the facility, in RFC "
+        "3339 format.",
+        examples=[datetime.fromisoformat("2023-04-12T23:45:00Z")],
+    )
+
+
+class Request(CamelCaseModel):
+    location_id: str = Field(
+        ...,
+        title="Location identifier",
+        description="Location identification number based on UN/LOCODE, IATA or other "
+        "similar identification number of the transport location.",
+        max_length=40,
+        examples=["FIOUL"],
+    )
+    start_time: datetime = Field(
+        ...,
+        title="Start time",
+        description="The start time of the evaluation period, in RFC 3339 format.",
+        examples=[datetime.fromisoformat("2023-04-12T23:20:50Z")],
+    )
+    end_time: datetime = Field(
+        ...,
+        title="End time",
+        description="The end time of the evaluation period, in RFC 3339 format.",
+        examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
+    )
+
+
+class Response(CamelCaseModel):
+    estimated_arrivals: list[EstimatedArrival] = Field(
+        ...,
+        title="Estimated arrivals",
+        description="Estimated arrival times.",
+    )
+
+
+DEFINITION = DataProductDefinition(
+    version="0.2.0",
+    title="Estimated arrival times",
+    description="Estimated arrival times of vehicles within a transport location.",
+    tags=["Logistics", "ETA"],
+    request=Request,
+    response=Response,
+)


### PR DESCRIPTION
Add new v0.2 version on `Transport/Vehicle/EstimatedArrivalTimes` .

- Deprecated v0.1.x
- v0.2.x includes field for waybills

For convenience a diff between the v0.1.x and v0.2.x versions:
![image](https://github.com/user-attachments/assets/09df89dc-ec57-4f1d-94aa-76920bd94540)

Commits are also structured to make reviewing each of them easier.