### PR TITLE
Remove reference to test definitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,6 @@ you finalize your pull requests.
   - [Adding new Data Product Definition](#adding-new-data-product-definition)
     - [Raw OpenApi spec](#raw-openapi-spec)
     - [Definition as a Python file](#definition-as-a-python-file)
-    - [Test version of definitions](#test-version-of-definitions)
   - [Pull Requests](#pull-requests)
   - [License](#license)
 
@@ -59,33 +58,9 @@ You have 2 options to use the converter:
 2. By creating a PR to the `main` branch. CI workflow will run the automation and push
    updated/generated files if needed.
 
-### Test version of definitions
-
-Everyone can submit to this repo whatever definitions they seem appropriate. It will
-allow to create data products using these definitions in a dataspace and experiment with
-the system. In order to do this:
-
-1. Fork this repository
-2. Create your definitions under `src/test/<your_github_username>/`
-3. Submit a PR and wait for CI Workflow to run and validate the changes
-4. Once PR is merged, it's possible to use the definitions in the dataspace
-
 ### Versioning of definitions
 
-#### Test definitions
-
-Definitions in `src/test/<your_github_username>/` should not have any version number in
-the filename and the version in the file needs to be of the form `0.0.x`. Each change to
-the definition should increment the version by one. Examples of `version` -> `filename`:
-
-- `0.0.1` -> `src/test/<your_github_username>/Foo/Bar.py`
-- `0.0.2` -> `src/test/<your_github_username>/Foo/Bar.py`
-- `0.0.3` -> `src/test/<your_github_username>/Foo/Bar.py`
-- ...
-
-#### Other definitions
-
-All other definitions have version numbers that are `>= 0.1.0` and they should follow
+Definitions have version numbers that are `>= 0.1.0` and they should follow
 [Semantic Versioning](https://semver.org/) of the form `MAJOR.MINOR.PATCH`.
 
 A general rule of thumb would be that the first definition should be versioned as

--- a/README.md
+++ b/README.md
@@ -22,9 +22,6 @@ format in this repository, you can check these resources:
 
 # Getting started
 
-Press `Use this template` to create a new repo from this template and define your data
-products there.
-
 Please check the [Contribution guidelines](./CONTRIBUTING.md) to learn how to submit new
 data product definitions in this repo.
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,9 @@ DataProductDefinition is a structure consisting of:
 
   Version is used in the info block of the OpenAPI spec. The data product definitions
   use [Semantic Versioning](https://semver.org/) of the form `MAJOR.MINOR.PATCH`, for
-  example `1.0.0`. Definitions in the `test` folder must have versions of the form
-  `0.0.z` and the version number should not exist in the filename of the definition. In
-  all other definitions the version number needs to be `>= 0.1.0` and the corresponding
-  short version number needs to be included in the filename. For example the version
-  `0.1.0` of the `Foo/Bar` definition would correspond to the file
+  example `1.0.0`. The version number needs to be `>= 0.1.0` in all definitions and the
+  corresponding short version number needs to be included in the filename. For example
+  the version `0.1.0` of the `Foo/Bar` definition would correspond to the file
   `src/Foo/Bar_v0.1.py`. For more details about versions and filenames see the
   [Versioning of definitions](CONTRIBUTING.md#versioning-of-definitions) section in the
   contribution guidelines.


### PR DESCRIPTION
Test definitions are not allowed on this dataspace.

Remove reference to using the template, this was accidentally left in place when taking the template into use in this repo.