### PR TITLE
Cleaning up common issues

### DIFF
--- a/DataProducts/Cargo/Metrics_v0.1.json
+++ b/DataProducts/Cargo/Metrics_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo metrics",
     "description": "The key metrics of the transported cargo",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Cargo/Metrics_v0.1": {
@@ -238,7 +238,7 @@
             ],
             "title": "Weight (kg)",
             "description": "The weight of the cargo item in kilograms.",
-            "examples": [2000]
+            "examples": [2000.0]
           },
           "volume": {
             "anyOf": [
@@ -294,7 +294,7 @@
           }
         },
         "type": "object",
-        "title": "CargoItem"
+        "title": "Cargo item"
       },
       "CargoMetricsRequest": {
         "properties": {
@@ -308,7 +308,7 @@
         },
         "type": "object",
         "required": ["waybillNumber"],
-        "title": "CargoMetricsRequest"
+        "title": "Cargo metrics request"
       },
       "CargoMetricsResponse": {
         "properties": {
@@ -329,7 +329,7 @@
             ],
             "title": "Weight (kg)",
             "description": "The weight of the cargo within the delivery in kilograms.",
-            "examples": [20000]
+            "examples": [20000.0]
           },
           "volume": {
             "anyOf": [
@@ -342,7 +342,7 @@
             ],
             "title": "Volume (m^3)",
             "description": "The volume of the cargo within the delivery in cubic meters.",
-            "examples": [50]
+            "examples": [50.0]
           },
           "cargoUnits": {
             "anyOf": [
@@ -368,7 +368,7 @@
         },
         "type": "object",
         "required": ["cargoType", "cargoItems"],
-        "title": "CargoMetricsResponse"
+        "title": "Cargo metrics response"
       },
       "CargoType": {
         "type": "string",

--- a/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.1.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational performance",
     "description": "General operational status data of a mobile work machine operating in a port.",
-    "version": "0.1.4"
+    "version": "0.1.5"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalPerformance_v0.1": {
@@ -256,7 +256,7 @@
           }
         },
         "type": "object",
-        "title": "CargoMoves"
+        "title": "Cargo moves"
       },
       "DataSourceError": {
         "properties": {
@@ -414,7 +414,7 @@
           }
         },
         "type": "object",
-        "title": "HoistMoves"
+        "title": "Hoist moves"
       },
       "NotFound": {
         "properties": {
@@ -477,7 +477,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -561,7 +561,7 @@
         },
         "type": "object",
         "required": ["runningHours", "distance"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.2.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalPerformance_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational performance",
     "description": "General operational status data of a mobile work machine operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalPerformance_v0.2": {
@@ -255,7 +255,7 @@
           }
         },
         "type": "object",
-        "title": "CargoMoves"
+        "title": "Cargo moves"
       },
       "DataSourceError": {
         "properties": {
@@ -413,7 +413,7 @@
           }
         },
         "type": "object",
-        "title": "HoistMoves"
+        "title": "Hoist moves"
       },
       "NotFound": {
         "properties": {
@@ -476,7 +476,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -567,7 +567,7 @@
         },
         "type": "object",
         "required": ["runningHours"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment operational status",
     "description": "General operational status data of a cargo handling equipment operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/CargoHandlingEquipment/OperationalStatus_v0.2": {
@@ -426,7 +426,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalStatusRequest"
+        "title": "Operational status request"
       },
       "OperationalStatusResponse": {
         "properties": {
@@ -523,7 +523,7 @@
         },
         "type": "object",
         "required": ["operationalState"],
-        "title": "OperationalStatusResponse"
+        "title": "Operational status response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
+++ b/DataProducts/CargoHandlingEquipment/OperationalStatus_v0.2.json
@@ -359,7 +359,7 @@
             "minimum": -90.0,
             "title": "Latitude (°)",
             "description": "The latitude coordinate in decimal degrees.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "longitude": {
             "type": "number",
@@ -367,7 +367,7 @@
             "minimum": -180.0,
             "title": "Longitude (°)",
             "description": "The longitude coordinate in decimal degrees.",
-            "examples": [24.945831]
+            "examples": [24.945]
           }
         },
         "type": "object",

--- a/DataProducts/CargoHandlingEquipment/SustainabilityMetrics_v0.1.json
+++ b/DataProducts/CargoHandlingEquipment/SustainabilityMetrics_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment sustainability metrics",
     "description": "The power source consumption for the sustainability evaluation of the cargo handling equipment operations.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/CargoHandlingEquipment/SustainabilityMetrics_v0.1": {
@@ -448,7 +448,7 @@
         },
         "type": "object",
         "required": ["id", "startTime", "endTime"],
-        "title": "SustainabilityRequest"
+        "title": "Sustainability request"
       },
       "SustainabilityResponse": {
         "properties": {
@@ -496,7 +496,7 @@
           }
         },
         "type": "object",
-        "title": "SustainabilityResponse"
+        "title": "Sustainability response"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
+++ b/DataProducts/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Battery manufacturing data sheet",
     "description": "Manufacturing data sheet as required by Battery Passport specification of the European Commission's Battery Act (2023/1542).",
-    "version": "0.1.6"
+    "version": "0.1.7"
   },
   "paths": {
     "/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1": {
@@ -351,7 +351,7 @@
           }
         },
         "type": "object",
-        "title": "ExpectedLifetime"
+        "title": "Expected lifetime"
       },
       "Forbidden": {
         "properties": {
@@ -450,7 +450,7 @@
         },
         "type": "object",
         "required": ["requirementConformity"],
-        "title": "LegalConformity"
+        "title": "Legal conformity"
       },
       "ManufacturerInformation": {
         "properties": {
@@ -521,7 +521,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the manufacturer's headquarters location in Alpha-3 format.",
+            "description": "The country code of the manufacturer's headquarters location in ISO 3166-1 alpha-3 format.",
             "examples": ["USA"]
           },
           "website": {
@@ -555,7 +555,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "ManufacturingDataSheetRequest": {
         "properties": {
@@ -569,14 +569,14 @@
           "id": {
             "type": "string",
             "maxLength": 40,
-            "title": "Id",
+            "title": "ID",
             "description": "The unique identifier of the product.",
             "examples": ["660e8400-e29b-41d4-a716-446655440000"]
           }
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "ManufacturingDataSheetRequest"
+        "title": "Manufacturing data sheet request"
       },
       "ManufacturingDataSheetResponse": {
         "properties": {
@@ -722,7 +722,7 @@
             ],
             "title": "Resistance (Ω)",
             "description": "The internal resistance of the battery pack in ohms.",
-            "examples": [0]
+            "examples": [0.1]
           },
           "roundTripEfficiency": {
             "anyOf": [
@@ -838,7 +838,7 @@
         },
         "type": "object",
         "required": ["recycledContent", "renewableContent", "extinguishingAgents"],
-        "title": "ManufacturingDataSheetResponse"
+        "title": "Manufacturing data sheet response"
       },
       "ManufacturingLocation": {
         "properties": {
@@ -853,7 +853,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code of the battery manufacturing location in Alpha-3 format.",
+            "description": "The country code of the battery manufacturing location in ISO 3166-1 alpha-3 format.",
             "examples": ["DEU"]
           },
           "city": {
@@ -872,7 +872,7 @@
           }
         },
         "type": "object",
-        "title": "ManufacturingLocation"
+        "title": "Manufacturing location"
       },
       "MaterialComposition": {
         "properties": {
@@ -906,7 +906,7 @@
         },
         "type": "object",
         "required": ["chemistry", "hazardousSubstances", "criticalRawMaterials"],
-        "title": "MaterialComposition"
+        "title": "Material composition"
       },
       "NotFound": {
         "properties": {
@@ -982,7 +982,7 @@
           }
         },
         "type": "object",
-        "title": "RecycledContent"
+        "title": "Recycled content"
       },
       "RenewableContent": {
         "properties": {
@@ -1015,7 +1015,7 @@
           }
         },
         "type": "object",
-        "title": "RenewableContent"
+        "title": "Renewable content"
       },
       "RoundTripEfficiency": {
         "properties": {
@@ -1047,7 +1047,7 @@
           }
         },
         "type": "object",
-        "title": "RoundTripEfficiency"
+        "title": "Round trip efficiency"
       },
       "ServiceUnavailable": {
         "properties": {
@@ -1104,7 +1104,7 @@
           }
         },
         "type": "object",
-        "title": "TemperatureRange"
+        "title": "Temperature range"
       },
       "Unauthorized": {
         "properties": {
@@ -1199,7 +1199,7 @@
           }
         },
         "type": "object",
-        "title": "VoltageLevels"
+        "title": "Voltage levels"
       }
     }
   },

--- a/DataProducts/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.json
+++ b/DataProducts/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Cargo handling equipment data sheet",
     "description": "General as-built data of a cargo handling equipment operating in a port.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2": {
@@ -326,7 +326,7 @@
         },
         "type": "object",
         "required": ["product", "id"],
-        "title": "DataSheetRequest"
+        "title": "Data sheet request"
       },
       "DataSheetResponse": {
         "properties": {
@@ -360,7 +360,6 @@
           },
           "manufacturerInformation": {
             "$ref": "#/components/schemas/ManufacturerInformation",
-            "title": "Manufacturer information",
             "description": "The details of the manufacturer."
           },
           "powerSource": {
@@ -439,7 +438,7 @@
           "netVehicleMass",
           "maxLoadCapacity"
         ],
-        "title": "DataSheetResponse"
+        "title": "Data sheet response"
       },
       "DataSourceError": {
         "properties": {
@@ -579,7 +578,7 @@
             "maxLength": 250,
             "title": "Name",
             "description": "The registered trade name of the manufacturer company.",
-            "examples": ["Equipment Manufacturer Company X"]
+            "examples": ["Equipment Manufacturer Example LTD"]
           },
           "website": {
             "anyOf": [
@@ -599,7 +598,7 @@
         },
         "type": "object",
         "required": ["name"],
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/Logistics/SeaTransportLeg/CarbonFootprint_v0.1.json
+++ b/DataProducts/Logistics/SeaTransportLeg/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Carbon footprint for a sea transport leg",
     "description": "Carbon footprint for a sea transport leg within a transport chain of a cargo compliant with GHG protocol Scope 3 transport emissions guidance and ISO 14083 standard.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/Logistics/SeaTransportLeg/CarbonFootprint_v0.1": {
@@ -387,7 +387,7 @@
               }
             ],
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -522,7 +522,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "fossilShare": {
             "anyOf": [

--- a/DataProducts/Logistics/TransportChain/CarbonFootprint/Push_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/CarbonFootprint/Push_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total carbon footprint for a transport chain",
     "description": "Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "paths": {
     "/Logistics/TransportChain/CarbonFootprint/Push_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -486,7 +486,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Logistics/TransportChain/CarbonFootprint_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total carbon footprint for a transport chain",
     "description": "Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Logistics/TransportChain/CarbonFootprint_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -493,7 +493,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.json
+++ b/DataProducts/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Monthly carbon footprint for logistics transport chains",
     "description": "Monthly logistics carbon footprint for a cargo owner compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "paths": {
     "/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1": {
@@ -382,7 +382,7 @@
             "minLength": 2,
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -466,7 +466,7 @@
         },
         "type": "object",
         "required": ["origin", "destination", "calculationMethod", "carbonFootprint"],
-        "title": "MonthlyFootprint"
+        "title": "Monthly footprint"
       },
       "NotFound": {
         "properties": {

--- a/DataProducts/Logistics/Transportation/TotalEmissions_v0.1.json
+++ b/DataProducts/Logistics/Transportation/TotalEmissions_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Total emissions for a transport chain",
     "description": "Total emissions for a transport chain compliant with GHG protocol Scope 3 transport emissions.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Logistics/Transportation/TotalEmissions_v0.1": {
@@ -370,7 +370,7 @@
             "type": "string",
             "pattern": "^[A-Z]{2}$",
             "title": "Country",
-            "description": "The country code in Alpha-2 format.",
+            "description": "The country code in ISO 3166-1 alpha-2 format.",
             "examples": ["DE"]
           }
         },
@@ -479,7 +479,7 @@
             ],
             "title": "Distance (km)",
             "description": "The distance of the transport chain in kilometers.",
-            "examples": [484]
+            "examples": [484.1]
           },
           "legCount": {
             "anyOf": [

--- a/DataProducts/Market/Electricity/Pricing/History_v0.1.json
+++ b/DataProducts/Market/Electricity/Pricing/History_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Electricity market price",
     "description": "Electricity price per MWh.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Market/Electricity/Pricing/History_v0.1": {
@@ -308,20 +308,20 @@
             "type": "string",
             "format": "date-time",
             "title": "Start time",
-            "description": "Start time of the requested time period, in RFC 3339.",
+            "description": "Start time of the requested time period, in RFC 3339 format.",
             "examples": ["2024-01-01T00:00:00+02:00"]
           },
           "endTime": {
             "type": "string",
             "format": "date-time",
             "title": "End time",
-            "description": "End time of the requested time period, in RFC 3339.",
+            "description": "End time of the requested time period, in RFC 3339 format.",
             "examples": ["2024-01-01T23:59:59+02:00"]
           }
         },
         "type": "object",
         "required": ["location", "startTime", "endTime"],
-        "title": "EnergyPriceRequest"
+        "title": "Energy price request"
       },
       "EnergyPriceResponse": {
         "properties": {
@@ -343,7 +343,7 @@
         },
         "type": "object",
         "required": ["currencyCode", "prices"],
-        "title": "EnergyPriceResponse"
+        "title": "Energy price response"
       },
       "Forbidden": {
         "properties": {
@@ -433,13 +433,13 @@
             "type": "string",
             "format": "date-time",
             "title": "Start time",
-            "description": "Start time of the pricing period, in RFC 3339.",
+            "description": "Start time of the pricing period, in RFC 3339 format.",
             "examples": ["2024-01-01T02:00:00+02:00"]
           }
         },
         "type": "object",
         "required": ["price", "startTime"],
-        "title": "PeriodPrice"
+        "title": "Period price"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Meteorology/Weather_v0.1.json
+++ b/DataProducts/Meteorology/Weather_v0.1.json
@@ -473,7 +473,7 @@
             "minimum": -90.0,
             "title": "Latitude (°)",
             "description": "The latitude coordinate of the desired location in degrees.",
-            "examples": [60.192059]
+            "examples": [60.192]
           },
           "lon": {
             "type": "number",
@@ -481,7 +481,7 @@
             "minimum": -180.0,
             "title": "Longitude (°)",
             "description": "The longitude coordinate of the desired location in degrees.",
-            "examples": [24.945831]
+            "examples": [24.945]
           },
           "when": {
             "anyOf": [

--- a/DataProducts/Meteorology/Weather_v0.1.json
+++ b/DataProducts/Meteorology/Weather_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Weather in metric units",
     "description": "Weather information for a given location, either current weather prediction or historical weather observations, using metric units.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Meteorology/Weather_v0.1": {
@@ -500,7 +500,7 @@
         },
         "type": "object",
         "required": ["lat", "lon"],
-        "title": "WeatherRequest"
+        "title": "Weather request"
       },
       "WeatherResponse": {
         "properties": {
@@ -524,7 +524,7 @@
             ],
             "title": "Humidity (%)",
             "description": "Current relative air humidity percentage.",
-            "examples": [72]
+            "examples": [72.0]
           },
           "pressure": {
             "anyOf": [
@@ -538,7 +538,7 @@
             ],
             "title": "Pressure (hPa)",
             "description": "Current air pressure in hectopascals.",
-            "examples": [1007]
+            "examples": [1007.0]
           },
           "windSpeed": {
             "anyOf": [
@@ -602,7 +602,7 @@
         },
         "type": "object",
         "required": ["temperature"],
-        "title": "WeatherResponse"
+        "title": "Weather response"
       }
     }
   },

--- a/DataProducts/Product/MachinedComponent/MeasurementReport_v0.1.json
+++ b/DataProducts/Product/MachinedComponent/MeasurementReport_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Machined component measurement report",
     "description": "The quality measurement report for a batch of machined components.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Product/MachinedComponent/MeasurementReport_v0.1": {
@@ -231,7 +231,7 @@
           "purchaseOrder": {
             "type": "string",
             "maxLength": 40,
-            "title": "Purchase order ",
+            "title": "Purchase order",
             "description": "The number of the purchase order related to the component.",
             "examples": ["12345"]
           },
@@ -252,7 +252,7 @@
         },
         "type": "object",
         "required": ["purchaseOrder", "componentName", "productionNumber"],
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "CustomerInformation": {
         "properties": {
@@ -261,7 +261,7 @@
             "maxLength": 250,
             "title": "Name",
             "description": "The name of the customer that has issued the component order.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "department": {
             "anyOf": [
@@ -275,12 +275,12 @@
             ],
             "title": "Department",
             "description": "The responsible department of the customer that has issued the component order.",
-            "examples": ["Department xyz"]
+            "examples": ["Department Name"]
           }
         },
         "type": "object",
         "required": ["name"],
-        "title": "CustomerInformation"
+        "title": "Customer information"
       },
       "DataSourceError": {
         "properties": {
@@ -448,7 +448,7 @@
         },
         "type": "object",
         "required": ["cmmSerialNumber"],
-        "title": "MeasurementEquipment"
+        "title": "Measurement equipment"
       },
       "MeasurementResult": {
         "properties": {
@@ -512,7 +512,7 @@
           "lowerTolerance",
           "deviation"
         ],
-        "title": "MeasurementResult"
+        "title": "Measurement result"
       },
       "MeasurementSetup": {
         "properties": {
@@ -615,7 +615,7 @@
           "measuredComponents",
           "measurementEquipment"
         ],
-        "title": "MeasurementSetup"
+        "title": "Measurement setup"
       },
       "NotFound": {
         "properties": {
@@ -678,17 +678,14 @@
         "properties": {
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "customerInformation": {
             "$ref": "#/components/schemas/CustomerInformation",
-            "title": "Customer information",
             "description": "The details of the customer issuing the order for the component."
           },
           "measurementSetup": {
             "$ref": "#/components/schemas/MeasurementSetup",
-            "title": "Measurement setup",
             "description": "The details describing the quality measurement setup."
           },
           "measurementResults": {

--- a/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
+++ b/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Metal component measurement report",
     "description": "The quality measurement report for metal components.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "paths": {
     "/Product/MetalComponent/MeasurementReport_v0.3": {
@@ -289,7 +289,7 @@
           }
         },
         "type": "object",
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "CustomerInformation": {
         "properties": {
@@ -306,7 +306,7 @@
             ],
             "title": "Name",
             "description": "The name of the customer that has issued the component order.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "department": {
             "anyOf": [
@@ -325,7 +325,7 @@
           }
         },
         "type": "object",
-        "title": "CustomerInformation"
+        "title": "Customer information"
       },
       "DataSourceError": {
         "properties": {
@@ -472,7 +472,7 @@
           }
         },
         "type": "object",
-        "title": "MeasurementEquipment"
+        "title": "Measurement equipment"
       },
       "MeasurementResult": {
         "properties": {
@@ -571,7 +571,7 @@
           }
         },
         "type": "object",
-        "title": "MeasurementResult"
+        "title": "Measurement result"
       },
       "MeasurementSetup": {
         "properties": {
@@ -646,7 +646,7 @@
               }
             ],
             "title": "Batch size",
-            "description": "The entire size of the batch that was manufactured under the same id.",
+            "description": "The entire size of the batch that was manufactured under the same ID.",
             "examples": [100]
           },
           "measuredItems": {
@@ -698,7 +698,7 @@
         },
         "type": "object",
         "required": ["measurementEquipment"],
-        "title": "MeasurementSetup"
+        "title": "Measurement setup"
       },
       "NotFound": {
         "properties": {
@@ -781,17 +781,14 @@
         "properties": {
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "customerInformation": {
             "$ref": "#/components/schemas/CustomerInformation",
-            "title": "Customer information",
             "description": "The details of the customer issuing the order for the component."
           },
           "measurementSetup": {
             "$ref": "#/components/schemas/MeasurementSetup",
-            "title": "Measurement setup",
             "description": "The details describing the quality measurement setup."
           },
           "measurementResults": {

--- a/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
+++ b/DataProducts/Product/MetalComponent/MeasurementReport_v0.3.json
@@ -321,7 +321,7 @@
             ],
             "title": "Department",
             "description": "The responsible department of the customer that has issued the component order.",
-            "examples": ["Department xyz"]
+            "examples": ["Department Name"]
           }
         },
         "type": "object",

--- a/DataProducts/Product/MetalComponent/Traceability_v0.3.json
+++ b/DataProducts/Product/MetalComponent/Traceability_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Metal component traceability information",
     "description": "The traceability information of a metal component.",
-    "version": "0.3.3"
+    "version": "0.3.4"
   },
   "paths": {
     "/Product/MetalComponent/Traceability_v0.3": {
@@ -293,7 +293,7 @@
           }
         },
         "type": "object",
-        "title": "CompanyIdentification"
+        "title": "Company identification"
       },
       "CompanyIdentifierScheme": {
         "type": "string",
@@ -318,10 +318,10 @@
           },
           "subComponentDeclaration": {
             "items": {
-              "$ref": "#/components/schemas/SubComponent"
+              "$ref": "#/components/schemas/Subcomponent"
             },
             "type": "array",
-            "title": "Sub component declaration",
+            "title": "Subcomponent declaration",
             "description": "List of declared subcomponents used in the component assembly."
           },
           "purchaseOrder": {
@@ -425,7 +425,7 @@
         },
         "type": "object",
         "required": ["subComponentDeclaration", "blanks"],
-        "title": "ComponentIdentification"
+        "title": "Component identification"
       },
       "DataSourceError": {
         "properties": {
@@ -568,7 +568,7 @@
             ],
             "title": "Name",
             "description": "The registered trade name of the manufacturer company.",
-            "examples": ["Company xyz"]
+            "examples": ["Example LLC"]
           },
           "identification": {
             "$ref": "#/components/schemas/CompanyIdentification",
@@ -603,12 +603,12 @@
             ],
             "title": "Contact email",
             "description": "The designated email contact for inquiries related to component manufacturing.",
-            "examples": ["contact@company.com"]
+            "examples": ["contact@example.com"]
           }
         },
         "type": "object",
         "required": ["identification"],
-        "title": "ManufacturerInformation"
+        "title": "Manufacturer information"
       },
       "NotFound": {
         "properties": {
@@ -650,7 +650,7 @@
           }
         },
         "type": "object",
-        "title": "ProcessIdentification"
+        "title": "Process identification"
       },
       "QueryLevel": {
         "type": "string",
@@ -740,17 +740,14 @@
           },
           "componentIdentification": {
             "$ref": "#/components/schemas/ComponentIdentification",
-            "title": "Component identification",
             "description": "The identifiers related to the component."
           },
           "manufacturerInformation": {
             "$ref": "#/components/schemas/ManufacturerInformation",
-            "title": "Manufacturer information",
             "description": "The details of the component manufacturer."
           },
           "processIdentification": {
-            "$ref": "#/components/schemas/ProcessIdentification",
-            "title": "Process identification"
+            "$ref": "#/components/schemas/ProcessIdentification"
           }
         },
         "type": "object",
@@ -782,7 +779,7 @@
         "title": "ServiceUnavailable",
         "description": "This response is reserved by Product Gateway."
       },
-      "SubComponent": {
+      "Subcomponent": {
         "properties": {
           "name": {
             "anyOf": [
@@ -816,7 +813,7 @@
           }
         },
         "type": "object",
-        "title": "SubComponent"
+        "title": "Subcomponent"
       },
       "Unauthorized": {
         "properties": {

--- a/DataProducts/Product/Sustainability/CarbonFootprint_v0.1.json
+++ b/DataProducts/Product/Sustainability/CarbonFootprint_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Product carbon footprint",
     "description": "The carbon footprint of manufacturing a product.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Product/Sustainability/CarbonFootprint_v0.1": {
@@ -464,7 +464,7 @@
               }
             ],
             "title": "Logistics footprint (kg of CO2e)",
-            "description": "The carbon footprint generated from the upstream logisitics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
+            "description": "The carbon footprint generated from the upstream logistics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
             "examples": [0.3]
           }
         },

--- a/DataProducts/Transport/Vehicle/Emissions_v0.1.json
+++ b/DataProducts/Transport/Vehicle/Emissions_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle emissions",
     "description": "The emissions of a transport vehicle.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Transport/Vehicle/Emissions_v0.1": {
@@ -336,7 +336,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "EmissionsRequest"
+        "title": "Emissions request"
       },
       "EmissionsResponse": {
         "properties": {
@@ -372,7 +372,7 @@
             "type": "number",
             "title": "Carbon dioxide (kg)",
             "description": "The mass of the carbon dioxide (CO2) emissions in kilograms.",
-            "examples": [4000]
+            "examples": [4000.0]
           },
           "nitrogenOxides": {
             "type": "number",
@@ -389,7 +389,7 @@
         },
         "type": "object",
         "required": ["carbonDioxide", "nitrogenOxides", "particulateMatter"],
-        "title": "EmissionsResponse"
+        "title": "Emissions response"
       },
       "Forbidden": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
+++ b/DataProducts/Transport/Vehicle/EstimatedArrivalTimes_v0.2.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Estimated arrival times",
     "description": "Estimated arrival times of vehicles within a transport location.",
-    "version": "0.2.3"
+    "version": "0.2.4"
   },
   "paths": {
     "/Transport/Vehicle/EstimatedArrivalTimes_v0.2": {
@@ -352,7 +352,7 @@
         },
         "type": "object",
         "required": ["vehicleId", "estimatedArrival", "waybills"],
-        "title": "EstimatedArrival"
+        "title": "Estimated arrival"
       },
       "Forbidden": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/OperationalPerformance_v0.1.json
+++ b/DataProducts/Transport/Vehicle/OperationalPerformance_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle operational performance",
     "description": "General operational performance data of a transport vehicle.",
-    "version": "0.1.3"
+    "version": "0.1.4"
   },
   "paths": {
     "/Transport/Vehicle/OperationalPerformance_v0.1": {
@@ -412,7 +412,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalPerformanceRequest"
+        "title": "Operational performance request"
       },
       "OperationalPerformanceResponse": {
         "properties": {
@@ -511,7 +511,7 @@
         },
         "type": "object",
         "required": ["runningHours", "distance"],
-        "title": "OperationalPerformanceResponse"
+        "title": "Operational performance response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
+++ b/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Transport vehicle operational status",
     "description": "General operational status data of a transport vehicle.",
-    "version": "0.1.2"
+    "version": "0.1.3"
   },
   "paths": {
     "/Transport/Vehicle/OperationalStatus_v0.1": {
@@ -421,7 +421,7 @@
         },
         "type": "object",
         "required": ["id"],
-        "title": "OperationalStatusRequest"
+        "title": "Operational status request"
       },
       "OperationalStatusResponse": {
         "properties": {
@@ -496,7 +496,7 @@
           }
         },
         "type": "object",
-        "title": "OperationalStatusResponse"
+        "title": "Operational status response"
       },
       "RateLimitExceeded": {
         "properties": {

--- a/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
+++ b/DataProducts/Transport/Vehicle/OperationalStatus_v0.1.json
@@ -357,7 +357,7 @@
             "type": "number",
             "title": "Latitude (°)",
             "description": "The latitude coordinate in decimal degrees.",
-            "examples": [60.192059],
+            "examples": [60.192],
             "gte": -90,
             "lte": 90
           },
@@ -365,7 +365,7 @@
             "type": "number",
             "title": "Longitude (°)",
             "description": "The longitude coordinate in decimal degrees.",
-            "examples": [24.945831],
+            "examples": [24.945],
             "gte": -180,
             "lte": 180
           }

--- a/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.3.json
+++ b/DataProducts/Transport/Vehicle/TurnaroundTimes_v0.3.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Vehicle turnaround times",
     "description": "Turnaround times of vehicles within a facility.",
-    "version": "0.3.2"
+    "version": "0.3.3"
   },
   "paths": {
     "/Transport/Vehicle/TurnaroundTimes_v0.3": {
@@ -475,7 +475,7 @@
         },
         "type": "object",
         "required": ["vehicleId", "entryTime"],
-        "title": "TurnaroundTime"
+        "title": "Turnaround time"
       },
       "TurnaroundTimeRequest": {
         "properties": {
@@ -503,7 +503,7 @@
         },
         "type": "object",
         "required": ["locationId", "startTime", "endTime"],
-        "title": "TurnaroundTimeRequest"
+        "title": "Turnaround time request"
       },
       "TurnaroundTimeResponse": {
         "properties": {
@@ -518,7 +518,7 @@
         },
         "type": "object",
         "required": ["turnaroundTimes"],
-        "title": "TurnaroundTimeResponse"
+        "title": "Turnaround time response"
       },
       "Unauthorized": {
         "properties": {

--- a/src/Cargo/Metrics_v0.1.py
+++ b/src/Cargo/Metrics_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoType(str, Enum):
@@ -17,7 +17,7 @@ class CargoItem(CamelCaseModel):
         None,
         title="Weight (kg)",
         description="The weight of the cargo item in kilograms.",
-        examples=[2000],
+        examples=[2000.0],
     )
     volume: Optional[float] = Field(
         None,
@@ -44,6 +44,8 @@ class CargoItem(CamelCaseModel):
         examples=[1.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo item")
+
 
 class CargoMetricsRequest(CamelCaseModel):
     waybill_number: str = Field(
@@ -53,6 +55,8 @@ class CargoMetricsRequest(CamelCaseModel):
         max_length=128,
         examples=["5308956234"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Cargo metrics request")
 
 
 class CargoMetricsResponse(CamelCaseModel):
@@ -66,13 +70,13 @@ class CargoMetricsResponse(CamelCaseModel):
         None,
         title="Weight (kg)",
         description="The weight of the cargo within the delivery in kilograms.",
-        examples=[20000],
+        examples=[20000.0],
     )
     volume: Optional[float] = Field(
         None,
         title="Volume (m^3)",
         description="The volume of the cargo within the delivery in cubic meters.",
-        examples=[50],
+        examples=[50.0],
     )
     cargo_units: Optional[int] = Field(
         None,
@@ -86,9 +90,11 @@ class CargoMetricsResponse(CamelCaseModel):
         description="The details of the cargo items within the delivery.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo metrics response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Cargo metrics",
     description="The key metrics of the transported cargo",

--- a/src/CargoHandlingEquipment/OperationalPerformance_v0.1.py
+++ b/src/CargoHandlingEquipment/OperationalPerformance_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoMoves(CamelCaseModel):
@@ -20,6 +20,8 @@ class CargoMoves(CamelCaseModel):
         examples=[53],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo moves")
+
 
 class HoistMoves(CamelCaseModel):
     lift: Optional[int] = Field(
@@ -34,6 +36,8 @@ class HoistMoves(CamelCaseModel):
         description="Count of lowering moves the cargo handling equipment has performed during the time period.",
         examples=[164],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Hoist moves")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -82,6 +86,8 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[75.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 class OperationalPerformanceRequest(CamelCaseModel):
     id: str = Field(
@@ -108,9 +114,11 @@ class OperationalPerformanceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.4",
+    version="0.1.5",
     strict_validation=False,
     deprecated=True,
     title="Cargo handling equipment operational performance",

--- a/src/CargoHandlingEquipment/OperationalPerformance_v0.2.py
+++ b/src/CargoHandlingEquipment/OperationalPerformance_v0.2.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class CargoMoves(CamelCaseModel):
@@ -20,6 +20,8 @@ class CargoMoves(CamelCaseModel):
         examples=[53],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Cargo moves")
+
 
 class HoistMoves(CamelCaseModel):
     lift: Optional[int] = Field(
@@ -34,6 +36,8 @@ class HoistMoves(CamelCaseModel):
         description="Count of lowering moves the cargo handling equipment has performed during the time period.",
         examples=[164],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Hoist moves")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -82,6 +86,8 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[75.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 class OperationalPerformanceRequest(CamelCaseModel):
     id: str = Field(
@@ -108,9 +114,11 @@ class OperationalPerformanceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment operational performance",
     description="General operational status data of a mobile work machine operating in "

--- a/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
+++ b/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
@@ -20,7 +20,7 @@ class Location(CamelCaseModel):
         description="The latitude coordinate in decimal degrees.",
         ge=-90.0,
         le=90.0,
-        examples=[60.192059],
+        examples=[60.192],
     )
     longitude: float = Field(
         ...,
@@ -28,7 +28,7 @@ class Location(CamelCaseModel):
         description="The longitude coordinate in decimal degrees.",
         ge=-180.0,
         le=180.0,
-        examples=[24.945831],
+        examples=[24.945],
     )
 
     model_config: ConfigDict = ConfigDict(title="Location")

--- a/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
+++ b/src/CargoHandlingEquipment/OperationalStatus_v0.2.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class OperationalState(str, Enum):
@@ -30,6 +30,8 @@ class Location(CamelCaseModel):
         le=180.0,
         examples=[24.945831],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class OperationalStatusResponse(CamelCaseModel):
@@ -83,6 +85,8 @@ class OperationalStatusResponse(CamelCaseModel):
         description="The location in GPS coordinates.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status response")
+
 
 class OperationalStatusRequest(CamelCaseModel):
     id: str = Field(
@@ -101,9 +105,11 @@ class OperationalStatusRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment operational status",
     description="General operational status data of a cargo handling equipment "

--- a/src/CargoHandlingEquipment/SustainabilityMetrics_v0.1.py
+++ b/src/CargoHandlingEquipment/SustainabilityMetrics_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class SustainabilityResponse(CamelCaseModel):
@@ -28,6 +28,8 @@ class SustainabilityResponse(CamelCaseModel):
         ge=0.0,
         examples=[560.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Sustainability response")
 
 
 class SustainabilityRequest(CamelCaseModel):
@@ -55,9 +57,11 @@ class SustainabilityRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Sustainability request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Cargo handling equipment sustainability metrics",
     description="The power source consumption for the sustainability evaluation of the "

--- a/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
+++ b/src/DigitalProductPassport/Battery/ManufacturingDataSheet_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import EmailStr, Field
+from pydantic import ConfigDict, EmailStr, Field
 
 
 class ManufacturingLocation(CamelCaseModel):
@@ -10,7 +10,7 @@ class ManufacturingLocation(CamelCaseModel):
         None,
         title="Country",
         pattern=r"^[A-Z]{3}$",
-        description="The country code of the battery manufacturing location in Alpha-3 "
+        description="The country code of the battery manufacturing location in ISO 3166-1 alpha-3 "
         "format.",
         examples=["DEU"],
     )
@@ -21,6 +21,8 @@ class ManufacturingLocation(CamelCaseModel):
         description="The city of the battery manufacturing location.",
         examples=["Hamburg"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturing location")
 
 
 class ManufacturerInformation(CamelCaseModel):
@@ -57,7 +59,7 @@ class ManufacturerInformation(CamelCaseModel):
         title="Country",
         pattern=r"^[A-Z]{3}$",
         description="The country code of the manufacturer's headquarters location in "
-        "Alpha-3 format.",
+        "ISO 3166-1 alpha-3 format.",
         examples=["USA"],
     )
     website: Optional[str] = Field(
@@ -74,6 +76,8 @@ class ManufacturerInformation(CamelCaseModel):
         description="The email address of the manufacturer.",
         examples=["info@example.com"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class BatteryCategory(str, Enum):
@@ -99,6 +103,8 @@ class RoundTripEfficiency(CamelCaseModel):
         examples=[60.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Round trip efficiency")
+
 
 class VoltageLevels(CamelCaseModel):
     nominal_voltage: Optional[float] = Field(
@@ -120,6 +126,8 @@ class VoltageLevels(CamelCaseModel):
         examples=[180.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Voltage levels")
+
 
 class TemperatureRange(CamelCaseModel):
     minimum_temperature: Optional[float] = Field(
@@ -140,6 +148,8 @@ class TemperatureRange(CamelCaseModel):
         le=100,
         ge=-100,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Temperature range")
 
 
 class ExpectedLifetime(CamelCaseModel):
@@ -166,6 +176,8 @@ class ExpectedLifetime(CamelCaseModel):
         examples=["1C"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Expected lifetime")
+
 
 class MaterialComposition(CamelCaseModel):
     chemistry: List[str] = Field(
@@ -188,6 +200,8 @@ class MaterialComposition(CamelCaseModel):
         examples=[["Cobalt"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Material composition")
+
 
 class RecycledContent(CamelCaseModel):
     substance_name: Optional[str] = Field(
@@ -205,6 +219,8 @@ class RecycledContent(CamelCaseModel):
         examples=[8.5],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Recycled content")
+
 
 class RenewableContent(CamelCaseModel):
     substance_name: Optional[str] = Field(
@@ -221,6 +237,8 @@ class RenewableContent(CamelCaseModel):
         "percentage by weight.",
         examples=[2.0],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Renewable content")
 
 
 class LegalConformity(CamelCaseModel):
@@ -246,6 +264,8 @@ class LegalConformity(CamelCaseModel):
         max_length=2083,
         examples=["https://example.com/EUdeclaration"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Legal conformity")
 
 
 class ManufacturingDataSheetResponse(CamelCaseModel):
@@ -315,7 +335,7 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         None,
         title="Resistance (Ω)",
         description="The internal resistance of the battery pack in ohms.",
-        examples=[0],
+        examples=[0.1],
     )
     round_trip_efficiency: Optional[RoundTripEfficiency] = Field(
         None,
@@ -375,6 +395,8 @@ class ManufacturingDataSheetResponse(CamelCaseModel):
         examples=[["foam", "carbon dioxide"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet response")
+
 
 class ManufacturingDataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -387,14 +409,16 @@ class ManufacturingDataSheetRequest(CamelCaseModel):
     id: str = Field(
         ...,
         max_length=40,
-        title="Id",
+        title="ID",
         description="The unique identifier of the product.",
         examples=["660e8400-e29b-41d4-a716-446655440000"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Manufacturing data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.6",
+    version="0.1.7",
     strict_validation=False,
     title="Battery manufacturing data sheet",
     description="Manufacturing data sheet as required by Battery Passport "

--- a/src/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.py
+++ b/src/DigitalProductPassport/CargoHandlingEquipment/DataSheet_v0.2.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EquipmentType(str, Enum):
@@ -33,7 +33,7 @@ class ManufacturerInformation(CamelCaseModel):
         max_length=250,
         title="Name",
         description="The registered trade name of the manufacturer company.",
-        examples=["Equipment Manufacturer Company X"],
+        examples=["Equipment Manufacturer Example LTD"],
     )
     website: Optional[str] = Field(
         None,
@@ -43,6 +43,8 @@ class ManufacturerInformation(CamelCaseModel):
         description="The website of the manufacturer.",
         examples=["https://example.com/"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class Batteries(CamelCaseModel):
@@ -83,6 +85,8 @@ class Batteries(CamelCaseModel):
         examples=[75.0],
         ge=0,
     )
+
+    model_config: ConfigDict = ConfigDict(title="Batteries")
 
 
 class DataSheetResponse(CamelCaseModel):
@@ -156,6 +160,8 @@ class DataSheetResponse(CamelCaseModel):
         examples=[6000.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet response")
+
 
 class DataSheetRequest(CamelCaseModel):
     product: str = Field(
@@ -173,9 +179,11 @@ class DataSheetRequest(CamelCaseModel):
         examples=["71b51878-8a00-11ee-b9d1-0242ac120002"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Data sheet request")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Cargo handling equipment data sheet",
     description="General as-built data of a cargo handling equipment operating in a "

--- a/src/Logistics/SeaTransportLeg/CarbonFootprint_v0.1.py
+++ b/src/Logistics/SeaTransportLeg/CarbonFootprint_v0.1.py
@@ -2,7 +2,7 @@ from datetime import date
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Location(CamelCaseModel):
@@ -25,10 +25,12 @@ class Location(CamelCaseModel):
     country: Optional[str] = Field(
         None,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -63,6 +65,8 @@ class Request(CamelCaseModel):
         examples=[date.fromisoformat("2025-02-06")],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     origin: Location = Field(
@@ -95,7 +99,7 @@ class Response(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     fossil_share: Optional[float] = Field(
         None,
@@ -122,9 +126,11 @@ class Response(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Carbon footprint for a sea transport leg",
     description="Carbon footprint for a sea transport leg within a transport chain of a cargo compliant with GHG protocol Scope 3 transport emissions guidance and ISO 14083 standard.",
     tags=["Logistics", "Emissions"],

--- a/src/Logistics/TransportChain/CarbonFootprint/Push_v0.1.py
+++ b/src/Logistics/TransportChain/CarbonFootprint/Push_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Literal, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -39,12 +39,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -92,7 +94,7 @@ class Request(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -131,6 +133,8 @@ class Request(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     status: Literal["ok"] = Field(
@@ -140,9 +144,11 @@ class Response(CamelCaseModel):
         examples=["ok"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.0",
+    version="0.1.1",
     title="Total carbon footprint for a transport chain",
     description="Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics"],

--- a/src/Logistics/TransportChain/CarbonFootprint_v0.1.py
+++ b/src/Logistics/TransportChain/CarbonFootprint_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -39,12 +39,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -62,6 +64,8 @@ class Request(CamelCaseModel):
         max_length=30,
         examples=["29771_01"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -95,7 +99,7 @@ class Response(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -134,9 +138,11 @@ class Response(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     title="Total carbon footprint for a transport chain",
     description="Total carbon footprint for a transport chain compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics"],

--- a/src/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.py
+++ b/src/Logistics/TransportChain/MonthlyCarbonFootprint_v0.1.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Location(CamelCaseModel):
@@ -24,12 +24,14 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         min_length=2,
         max_length=2,
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class MonthlyFootprint(CamelCaseModel):
@@ -84,6 +86,8 @@ class MonthlyFootprint(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Monthly footprint")
+
 
 class Request(CamelCaseModel):
     id: str = Field(
@@ -102,6 +106,8 @@ class Request(CamelCaseModel):
         examples=["2025-08"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     monthly_footprints: list[MonthlyFootprint] = Field(
@@ -110,9 +116,11 @@ class Response(CamelCaseModel):
         description="A list of monthly carbon footprints for transport chains.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.1",
+    version="0.1.2",
     title="Monthly carbon footprint for logistics transport chains",
     description="Monthly logistics carbon footprint for a cargo owner compliant with GHG protocol Scope 3 transport emissions based on ISO 14083 standard.",
     tags=["Logistics", "Carbon footprint", "Emissions"],

--- a/src/Logistics/Transportation/TotalEmissions_v0.1.py
+++ b/src/Logistics/Transportation/TotalEmissions_v0.1.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional, Set
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class IdType(str, Enum):
@@ -30,10 +30,12 @@ class Location(CamelCaseModel):
     country: str = Field(
         ...,
         title="Country",
-        description="The country code in Alpha-2 format.",
+        description="The country code in ISO 3166-1 alpha-2 format.",
         pattern=r"^[A-Z]{2}$",
         examples=["DE"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Location")
 
 
 class Request(CamelCaseModel):
@@ -50,6 +52,8 @@ class Request(CamelCaseModel):
         max_length=30,
         examples=["29771_01"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -82,7 +86,7 @@ class Response(CamelCaseModel):
         None,
         title="Distance (km)",
         description="The distance of the transport chain in kilometers.",
-        examples=[484],
+        examples=[484.1],
     )
     leg_count: Optional[int] = Field(
         None,
@@ -121,9 +125,11 @@ class Response(CamelCaseModel):
         examples=[25.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     deprecated=True,
     title="Total emissions for a transport chain",

--- a/src/Market/Electricity/Pricing/History_v0.1.py
+++ b/src/Market/Electricity/Pricing/History_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import List
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EnergyPriceRequest(CamelCaseModel):
@@ -15,7 +15,7 @@ class EnergyPriceRequest(CamelCaseModel):
     start_time: datetime.datetime = Field(
         ...,
         title="Start time",
-        description="Start time of the requested time period, in RFC 3339.",
+        description="Start time of the requested time period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -31,7 +31,7 @@ class EnergyPriceRequest(CamelCaseModel):
     end_time: datetime.datetime = Field(
         ...,
         title="End time",
-        description="End time of the requested time period, in RFC 3339.",
+        description="End time of the requested time period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -45,6 +45,8 @@ class EnergyPriceRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Energy price request")
+
 
 class PeriodPrice(CamelCaseModel):
     price: float = Field(
@@ -56,7 +58,7 @@ class PeriodPrice(CamelCaseModel):
     start_time: datetime.datetime = Field(
         ...,
         title="Start time",
-        description="Start time of the pricing period, in RFC 3339.",
+        description="Start time of the pricing period, in RFC 3339 format.",
         examples=[
             datetime.datetime(
                 2024,
@@ -69,6 +71,8 @@ class PeriodPrice(CamelCaseModel):
             )
         ],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Period price")
 
 
 class EnergyPriceResponse(CamelCaseModel):
@@ -85,9 +89,11 @@ class EnergyPriceResponse(CamelCaseModel):
         description="List of the prices for the given time period.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Energy price response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Electricity market price",
     description="Electricity price per MWh.",

--- a/src/Meteorology/Weather_v0.1.py
+++ b/src/Meteorology/Weather_v0.1.py
@@ -12,7 +12,7 @@ class WeatherRequest(CamelCaseModel):
         description="The latitude coordinate of the desired location in degrees.",
         ge=-90.0,
         le=90.0,
-        examples=[60.192059],
+        examples=[60.192],
     )
     lon: float = Field(
         ...,
@@ -20,7 +20,7 @@ class WeatherRequest(CamelCaseModel):
         description="The longitude coordinate of the desired location in degrees.",
         ge=-180.0,
         le=180.0,
-        examples=[24.945831],
+        examples=[24.945],
     )
     when: Optional[datetime.datetime] = Field(
         None,

--- a/src/Meteorology/Weather_v0.1.py
+++ b/src/Meteorology/Weather_v0.1.py
@@ -2,7 +2,7 @@ import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class WeatherRequest(CamelCaseModel):
@@ -31,6 +31,8 @@ class WeatherRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Weather request")
+
 
 class WeatherResponse(CamelCaseModel):
     temperature: float = Field(
@@ -46,14 +48,14 @@ class WeatherResponse(CamelCaseModel):
         description="Current relative air humidity percentage.",
         ge=0.0,
         le=100.0,
-        examples=[72],
+        examples=[72.0],
     )
     pressure: Optional[float] = Field(
         None,
         title="Pressure (hPa)",
         description="Current air pressure in hectopascals.",
         ge=0.0,
-        examples=[1007],
+        examples=[1007.0],
     )
     wind_speed: Optional[float] = Field(
         None,
@@ -87,9 +89,11 @@ class WeatherResponse(CamelCaseModel):
         examples=[320.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Weather response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Weather in metric units",
     description="Weather information for a given location, either current "

--- a/src/Product/MachinedComponent/MeasurementReport_v0.1.py
+++ b/src/Product/MachinedComponent/MeasurementReport_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class MeasurementEquipment(CamelCaseModel):
@@ -28,11 +28,13 @@ class MeasurementEquipment(CamelCaseModel):
         examples=["mp-001-rv02"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement equipment")
+
 
 class ComponentIdentification(CamelCaseModel):
     purchase_order: str = Field(
         ...,
-        title="Purchase order ",
+        title="Purchase order",
         description="The number of the purchase order related to the component.",
         max_length=40,
         examples=["12345"],
@@ -52,6 +54,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["pn-20240205-00123"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class CustomerInformation(CamelCaseModel):
     name: str = Field(
@@ -59,15 +63,17 @@ class CustomerInformation(CamelCaseModel):
         title="Name",
         description="The name of the customer that has issued the component order.",
         max_length=250,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     department: Optional[str] = Field(
         None,
         title="Department",
         description="The responsible department of the customer that has issued the component order.",
         max_length=250,
-        examples=["Department xyz"],
+        examples=["Department Name"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Customer information")
 
 
 class MeasurementSetup(CamelCaseModel):
@@ -130,6 +136,8 @@ class MeasurementSetup(CamelCaseModel):
         description="The identifiers of the equipment used in the measuring of the component.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement setup")
+
 
 class MeasurementResult(CamelCaseModel):
     feature_name: str = Field(
@@ -176,6 +184,8 @@ class MeasurementResult(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement result")
+
 
 class Request(CamelCaseModel):
     id: str = Field(
@@ -185,6 +195,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["b1a-0723y-00165"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -209,9 +221,11 @@ class Response(CamelCaseModel):
         description="The results of the quality measurements.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     deprecated=True,
     title="Machined component measurement report",

--- a/src/Product/MetalComponent/MeasurementReport_v0.3.py
+++ b/src/Product/MetalComponent/MeasurementReport_v0.3.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -46,6 +46,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["xy00012345687"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class CustomerInformation(CamelCaseModel):
     name: Optional[str] = Field(
@@ -54,7 +56,7 @@ class CustomerInformation(CamelCaseModel):
         description="The name of the customer that has issued the component order.",
         min_length=0,
         max_length=250,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     department: Optional[str] = Field(
         None,
@@ -64,6 +66,8 @@ class CustomerInformation(CamelCaseModel):
         max_length=250,
         examples=["Department xyz"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Customer information")
 
 
 class MeasurementResult(CamelCaseModel):
@@ -112,6 +116,8 @@ class MeasurementResult(CamelCaseModel):
         examples=[True],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Measurement result")
+
 
 class MeasurementEquipment(CamelCaseModel):
     machine_serial_number: Optional[str] = Field(
@@ -122,6 +128,8 @@ class MeasurementEquipment(CamelCaseModel):
         max_length=40,
         examples=["mfg-model-xxxx-yyyy"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Measurement equipment")
 
 
 class MeasurementSetup(CamelCaseModel):
@@ -160,7 +168,7 @@ class MeasurementSetup(CamelCaseModel):
     batch_size: Optional[int] = Field(
         None,
         title="Batch size",
-        description="The entire size of the batch that was manufactured under the same id.",
+        description="The entire size of the batch that was manufactured under the same ID.",
         examples=[100],
     )
     measured_items: Optional[int] = Field(
@@ -185,6 +193,8 @@ class MeasurementSetup(CamelCaseModel):
         title="Measurement equipment",
         description="The identifiers of the equipment used to measure the component.",
     )
+
+    model_config: ConfigDict = ConfigDict(title="Measurement setup")
 
 
 class Request(CamelCaseModel):
@@ -211,6 +221,8 @@ class Request(CamelCaseModel):
         examples=["batch-12345"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     component_identification: ComponentIdentification = Field(
@@ -234,9 +246,11 @@ class Response(CamelCaseModel):
         description="The results of the quality measurements.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.2",
+    version="0.3.3",
     strict_validation=False,
     title="Metal component measurement report",
     description="The quality measurement report for metal components.",

--- a/src/Product/MetalComponent/MeasurementReport_v0.3.py
+++ b/src/Product/MetalComponent/MeasurementReport_v0.3.py
@@ -64,7 +64,7 @@ class CustomerInformation(CamelCaseModel):
         description="The responsible department of the customer that has issued the component order.",
         min_length=0,
         max_length=250,
-        examples=["Department xyz"],
+        examples=["Department Name"],
     )
 
     model_config: ConfigDict = ConfigDict(title="Customer information")

--- a/src/Product/MetalComponent/Traceability_v0.3.py
+++ b/src/Product/MetalComponent/Traceability_v0.3.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -17,7 +17,7 @@ class CompanyIdentifierScheme(str, Enum):
     DUNS = "duns"
 
 
-class SubComponent(CamelCaseModel):
+class Subcomponent(CamelCaseModel):
     name: Optional[str] = Field(
         None,
         title="Name",
@@ -34,6 +34,8 @@ class SubComponent(CamelCaseModel):
         max_length=20,
         examples=["batch-2024-ssbolt-0037"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Subcomponent")
 
 
 class Blank(CamelCaseModel):
@@ -54,6 +56,8 @@ class Blank(CamelCaseModel):
         examples=["forging billet"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Blank")
+
 
 class CompanyIdentification(CamelCaseModel):
     identifier_scheme: Optional[CompanyIdentifierScheme] = Field(
@@ -71,6 +75,8 @@ class CompanyIdentification(CamelCaseModel):
         examples=["1234567890123"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Company identification")
+
 
 class ProcessIdentification(CamelCaseModel):
     identifier: Optional[str] = Field(
@@ -82,6 +88,8 @@ class ProcessIdentification(CamelCaseModel):
         examples=["procset-metal-2024-0458"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Process identification")
+
 
 class ComponentIdentification(CamelCaseModel):
     name: Optional[str] = Field(
@@ -91,9 +99,9 @@ class ComponentIdentification(CamelCaseModel):
         min_length=0,
         max_length=150,
     )
-    sub_component_declaration: list[SubComponent] = Field(
+    sub_component_declaration: list[Subcomponent] = Field(
         ...,
-        title="Sub component declaration",
+        title="Subcomponent declaration",
         description="List of declared subcomponents used in the component assembly.",
     )
     purchase_order: Optional[str] = Field(
@@ -150,6 +158,8 @@ class ComponentIdentification(CamelCaseModel):
         examples=["Rev A"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Component identification")
+
 
 class ManufacturerInformation(CamelCaseModel):
     name: Optional[str] = Field(
@@ -158,7 +168,7 @@ class ManufacturerInformation(CamelCaseModel):
         description="The registered trade name of the manufacturer company.",
         min_length=0,
         max_length=40,
-        examples=["Company xyz"],
+        examples=["Example LLC"],
     )
     identification: CompanyIdentification = Field(
         ...,
@@ -179,8 +189,10 @@ class ManufacturerInformation(CamelCaseModel):
         description="The designated email contact for inquiries related to component manufacturing.",
         min_length=0,
         max_length=40,
-        examples=["contact@company.com"],
+        examples=["contact@example.com"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Manufacturer information")
 
 
 class Request(CamelCaseModel):
@@ -206,6 +218,8 @@ class Request(CamelCaseModel):
         max_length=40,
         examples=["batch-12345"],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Request")
 
 
 class Response(CamelCaseModel):
@@ -237,9 +251,11 @@ class Response(CamelCaseModel):
         description=None,
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.3",
+    version="0.3.4",
     strict_validation=False,
     title="Metal component traceability information",
     description="The traceability information of a metal component.",

--- a/src/Product/MetalComponent/Traceability_v0.3.py
+++ b/src/Product/MetalComponent/Traceability_v0.3.py
@@ -99,6 +99,7 @@ class ComponentIdentification(CamelCaseModel):
         min_length=0,
         max_length=150,
     )
+    # TODO: subcomponent_declaration
     sub_component_declaration: list[Subcomponent] = Field(
         ...,
         title="Subcomponent declaration",

--- a/src/Product/Sustainability/CarbonFootprint_v0.1.py
+++ b/src/Product/Sustainability/CarbonFootprint_v0.1.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class QueryLevel(str, Enum):
@@ -33,6 +33,8 @@ class Request(CamelCaseModel):
         examples=["batch-12345"],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     material_footprint: Optional[float] = Field(
@@ -50,13 +52,15 @@ class Response(CamelCaseModel):
     logistics_footprint: Optional[float] = Field(
         None,
         title="Logistics footprint (kg of CO2e)",
-        description="The carbon footprint generated from the upstream logisitics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
+        description="The carbon footprint generated from the upstream logistics of delivering the product materials to manufacturing calculated as kilograms of carbon dioxide equivalents using Product Category Rule (PCR) methods.",
         examples=[0.3],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Product carbon footprint",
     description="The carbon footprint of manufacturing a product.",

--- a/src/Transport/Vehicle/Emissions_v0.1.py
+++ b/src/Transport/Vehicle/Emissions_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EmissionsRequest(CamelCaseModel):
@@ -26,6 +26,8 @@ class EmissionsRequest(CamelCaseModel):
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Emissions request")
+
 
 class EmissionsResponse(CamelCaseModel):
     start_time: Optional[datetime] = Field(
@@ -44,7 +46,7 @@ class EmissionsResponse(CamelCaseModel):
         ...,
         title="Carbon dioxide (kg)",
         description="The mass of the carbon dioxide (CO2) emissions in kilograms.",
-        examples=[4000],
+        examples=[4000.0],
     )
     nitrogen_oxides: float = Field(
         ...,
@@ -59,9 +61,11 @@ class EmissionsResponse(CamelCaseModel):
         examples=[0.05],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Emissions response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Transport vehicle emissions",
     description="The emissions of a transport vehicle.",

--- a/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
+++ b/src/Transport/Vehicle/EstimatedArrivalTimes_v0.2.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class EstimatedArrival(CamelCaseModel):
@@ -42,6 +42,8 @@ class EstimatedArrival(CamelCaseModel):
         examples=[["DGT1234567", "FTP7654321"]],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Estimated arrival")
+
 
 class Request(CamelCaseModel):
     location_id: str = Field(
@@ -65,6 +67,8 @@ class Request(CamelCaseModel):
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Request")
+
 
 class Response(CamelCaseModel):
     estimated_arrivals: list[EstimatedArrival] = Field(
@@ -73,9 +77,11 @@ class Response(CamelCaseModel):
         description="Estimated arrival times.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.2.3",
+    version="0.2.4",
     strict_validation=False,
     title="Estimated arrival times",
     description="Estimated arrival times of vehicles within a transport location.",

--- a/src/Transport/Vehicle/OperationalPerformance_v0.1.py
+++ b/src/Transport/Vehicle/OperationalPerformance_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class OperationalPerformanceRequest(CamelCaseModel):
@@ -25,6 +25,8 @@ class OperationalPerformanceRequest(CamelCaseModel):
         description="The end time of the performance period in, RFC 3339 format.",
         examples=[datetime.fromisoformat("2023-05-12T23:20:50Z")],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operational performance request")
 
 
 class OperationalPerformanceResponse(CamelCaseModel):
@@ -77,9 +79,11 @@ class OperationalPerformanceResponse(CamelCaseModel):
         examples=[50.0],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational performance response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.3",
+    version="0.1.4",
     strict_validation=False,
     title="Transport vehicle operational performance",
     description="General operational performance data of a transport vehicle.",

--- a/src/Transport/Vehicle/OperationalStatus_v0.1.py
+++ b/src/Transport/Vehicle/OperationalStatus_v0.1.py
@@ -12,7 +12,7 @@ class Location(CamelCaseModel):
         description="The latitude coordinate in decimal degrees.",
         gte=-90,
         lte=90,
-        examples=[60.192059],
+        examples=[60.192],
     )
     longitude: float = Field(
         ...,
@@ -20,7 +20,7 @@ class Location(CamelCaseModel):
         description="The longitude coordinate in decimal degrees.",
         gte=-180,
         lte=180,
-        examples=[24.945831],
+        examples=[24.945],
     )
 
     model_config: ConfigDict = ConfigDict(title="Location")

--- a/src/Transport/Vehicle/OperationalStatus_v0.1.py
+++ b/src/Transport/Vehicle/OperationalStatus_v0.1.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class Location(CamelCaseModel):
@@ -23,6 +23,8 @@ class Location(CamelCaseModel):
         examples=[24.945831],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Location")
+
 
 class OperationalStatusRequest(CamelCaseModel):
     id: str = Field(
@@ -38,6 +40,8 @@ class OperationalStatusRequest(CamelCaseModel):
         description="Request the vehicle's status information at or before this given time, in RFC 3339 format. If empty, provide latest value.",
         examples=[datetime.fromisoformat("2023-04-12T23:20:50Z")],
     )
+
+    model_config: ConfigDict = ConfigDict(title="Operational status request")
 
 
 class OperationalStatusResponse(CamelCaseModel):
@@ -75,9 +79,11 @@ class OperationalStatusResponse(CamelCaseModel):
         description="The location in GPS coordinates.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Operational status response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.1.2",
+    version="0.1.3",
     strict_validation=False,
     title="Transport vehicle operational status",
     description="General operational status data of a transport vehicle.",

--- a/src/Transport/Vehicle/TurnaroundTimes_v0.3.py
+++ b/src/Transport/Vehicle/TurnaroundTimes_v0.3.py
@@ -2,7 +2,7 @@ import datetime
 from typing import List, Optional
 
 from definition_tooling.converter import CamelCaseModel, DataProductDefinition
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 
 class TurnaroundTime(CamelCaseModel):
@@ -44,6 +44,8 @@ class TurnaroundTime(CamelCaseModel):
         examples=[3600],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time")
+
 
 class TurnaroundTimeRequest(CamelCaseModel):
     location_id: str = Field(
@@ -73,6 +75,8 @@ class TurnaroundTimeRequest(CamelCaseModel):
         ],
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time request")
+
 
 class TurnaroundTimeResponse(CamelCaseModel):
     turnaround_times: List[TurnaroundTime] = Field(
@@ -81,9 +85,11 @@ class TurnaroundTimeResponse(CamelCaseModel):
         description="The list of turnaround times of vehicles within the facility.",
     )
 
+    model_config: ConfigDict = ConfigDict(title="Turnaround time response")
+
 
 DEFINITION = DataProductDefinition(
-    version="0.3.2",
+    version="0.3.3",
     strict_validation=False,
     title="Vehicle turnaround times",
     description="Turnaround times of vehicles within a facility.",


### PR DESCRIPTION
Fixed common formatting and consistency issues.

- Using consistent naming for ISO 3166-1 alpha-2/3
- "RFC 3339 format" instead of just "RFC 3339"
- Float examples for float fields
- Company xyz -> Example LLC etc.
- company.com -> example.com
- Adding sensible titles to models.
- Updating patch version numbers of affected files
- Cleaned up extra spaces
- Fixed spelling errors
- Removed unnecessary level of detail from coordinates